### PR TITLE
Fix for kodi 18 rejecting addon versions

### DIFF
--- a/manage_repo.py
+++ b/manage_repo.py
@@ -168,7 +168,8 @@ def write_changelog_file(addon_location, changelog):
 
 
 def get_version(repo):
-    return repo.git.describe().lstrip('v')
+    return repo.git.describe(
+        ).lstrip('v').replace('-','~',1).replace('-', '+git', 1)
 
 
 def update_news(metadata_path, changelog):


### PR DESCRIPTION
I've just discovered that builds of Kodi since mid April have been rejecting the development versions (doesn't like hyphens).

This change adopts the scheme that Kodi itself uses, so 1.1.3-2-g83a0271 becomes 1.1.3~2+gitg83a0271

The nested replace feels a bit iffy but I couldn't think of a cleaner way to do it and it seems to work well.